### PR TITLE
Support different Orientations. See #7

### DIFF
--- a/CRToast/CRToast.m
+++ b/CRToast/CRToast.m
@@ -128,7 +128,7 @@ static UIImage  *                   kCRImageDefault                         = ni
 #pragma mark - Layout Helper Functions
 
 static CGFloat const CRStatusBarDefaultHeight = 44.0f;
-static CGFloat const CRStatusBariPhoneLandscape = 30.0f;
+static CGFloat const CRStatusBariPhoneLandscape = 33.0f;
 
 static CGFloat CRGetStatusBarHeight() {
     return (UIDeviceOrientationIsLandscape([UIApplication sharedApplication].statusBarOrientation)) ?
@@ -638,7 +638,16 @@ static NSString *const kCRToastManagerCollisionBoundryIdentifier = @"kCRToastMan
 - (void)displayNotification:(CRToast*)notification {
     _notificationWindow.hidden = NO;
     CGSize notificationSize = CRNotificationViewSize(notification.notificationType);
-    _notificationWindow.rootViewController.view.frame = CGRectMake(0, 0, notificationSize.width, notificationSize.height);
+    
+    if ([UIApplication sharedApplication].statusBarOrientation == UIInterfaceOrientationLandscapeLeft) {
+        _notificationWindow.rootViewController.view.frame = CGRectMake(0, 0, notificationSize.height, notificationSize.width);
+    } else if ([UIApplication sharedApplication].statusBarOrientation == UIInterfaceOrientationLandscapeRight) {
+        _notificationWindow.rootViewController.view.frame = CGRectMake([[UIScreen mainScreen] bounds].size.width-notificationSize.height, 0, notificationSize.height, notificationSize.width);
+    } else if ([UIApplication sharedApplication].statusBarOrientation == UIInterfaceOrientationPortraitUpsideDown) {
+        _notificationWindow.rootViewController.view.frame = CGRectMake([[UIScreen mainScreen] bounds].size.width, [[UIScreen mainScreen] bounds].size.height, notificationSize.width, notificationSize.height);
+    } else {
+        _notificationWindow.rootViewController.view.frame = CGRectMake(0, 0, notificationSize.width, notificationSize.height);
+    }
 
     UIView *statusBarView = notification.statusBarView;
     statusBarView.frame = _notificationWindow.rootViewController.view.bounds;


### PR DESCRIPTION
This should handle all screen orientations correctly. (Not entirely sure about portrait upsidedown, as I couldn't get the demo to rotate upside down, but it should be correct.)

I changed the landscape navigation bar height, as it was not high enough for me. This way it is.
Current problem is that when the device is rotated, while a notification is displayed, that notification  will not change it's width. But as I'm not quite sure how to handle that, here's the current progress, as it already makes things better.
