### PR TITLE
Fixed notifications not being dismissed when `animated` is NO

### DIFF
--- a/CRToast/CRToast.m
+++ b/CRToast/CRToast.m
@@ -1156,7 +1156,8 @@ CRToastAnimationStepBlock CRToastOutwardAnimationsSetupBlock(CRToastManager *wea
         __weak __block typeof(self) weakSelf = self;
         CRToastOutwardAnimationsSetupBlock(weakSelf)();
     } else {
-        [[(CRToast*)_notifications.firstObject notificationView] removeFromSuperview];
+        __weak __block typeof(self) weakSelf = self;
+        CRToastOutwardAnimationsCompletionBlock(weakSelf)(YES);
     }
 }
 


### PR DESCRIPTION
Fix for #42

---

This could possibly be better solved by extracting some code from `CRToastOutwardAnimationsCompletionBlock` in to a more generic method/function. Let me know if that is preferable.
