### PR TITLE
have travis-ci upgrade `xctool` before building

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ language: objective-c
 xcode_project: CRToastDemo.xcodeproj
 xcode_scheme: CRToastTests
 xcode_sdk: iphonesimulator7.0
+before_script:
+  - brew update
+  - brew upgrade xctool


### PR DESCRIPTION
Possible fix for random Travis-CI failures. 

https://github.com/travis-ci/travis-ci/issues/1630
https://github.com/travis-ci/travis-ci/issues/1825
