### PR TITLE
Window level higher than normal

### DIFF
--- a/CRToast/CRToast.m
+++ b/CRToast/CRToast.m
@@ -1230,7 +1230,7 @@ CRToastAnimationStepBlock CRToastOutwardAnimationsSetupBlock(CRToastManager *wea
 
     _notificationWindow.frame = containerFrame;
     _notificationWindow.rootViewController.view.frame = CGRectMake(0, 0, CGRectGetWidth(containerFrame), CGRectGetHeight(containerFrame));
-    _notificationWindow.windowLevel = notification.displayUnderStatusBar ? UIWindowLevelNormal : UIWindowLevelStatusBar;
+    _notificationWindow.windowLevel = notification.displayUnderStatusBar ? UIWindowLevelNormal + 1 : UIWindowLevelStatusBar;
     
     UIView *statusBarView = notification.statusBarView;
     statusBarView.frame = _notificationWindow.rootViewController.view.bounds;


### PR DESCRIPTION
When displaying the Toast under status bar the windowLevel is set to `UIWindowLevelNormal`. However, this is not fully correct because this window is on top of the main application window. When using this library with others like `SVProgressHUD`, they have problems identifying the proper place to insert themselves. Just adding a small amount (+1) works and configures this window on proper level (above the app).

A similar idea could be applied to the UIWindowLevelStatusBar level also if you want to.
