### PR TITLE
Fix for device rotation glitches

### DIFF
--- a/CRToast/CRToast.m
+++ b/CRToast/CRToast.m
@@ -1111,15 +1111,6 @@ static CGFloat const CRStatusBarViewUnderStatusBarYOffsetAdjustment = -5;
 
 @implementation CRToastContainerView
 
-- (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent*)event {
-    for (UIView *subview in self.subviews) {
-        if ([subview hitTest:[self convertPoint:point toView:subview] withEvent:event] != nil) {
-            return YES;
-        }
-    }
-    return NO;
-}
-
 @end
 
 #pragma mark - CRToastViewController


### PR DESCRIPTION
After coming back to this again and again, I finally understand what the problem is: The UIWindow we show above the app must have the same frame as the screen. When the device is rotated, black squares are placed on all sides of the window during the rotation (the black you see in the corners). In our case our window was small and in the middle of the screen, so those black squares were being drawn over our interface :(

:package: ready for merge once all tasks complete:
- [x] Fix touches sometimes not going through to real interface (may need hit test in more places)
- [x] Fix Toast view height not adjusting to the match the navigation bar (which changes height on rotation)
