### PR TITLE
Fix CRToastInteractionResponder nil block crash.

### DIFF
--- a/CRToast/CRToast.m
+++ b/CRToast/CRToast.m
@@ -547,14 +547,20 @@ NSArray * CRToastGenericRecognizersMake(id target, CRToastInteractionResponder *
     if (swipeGestureRecognizer.automaticallyDismiss) {
         [CRToastManager dismissNotification:YES];
     }
-    swipeGestureRecognizer.block(swipeGestureRecognizer.interactionType);
+    
+    if (swipeGestureRecognizer.block) {
+        swipeGestureRecognizer.block(swipeGestureRecognizer.interactionType);
+    }
 }
 
 - (void)tapGestureRecognizerTapped:(CRToastTapGestureRecognizer*)tapGestureRecognizer {
     if (tapGestureRecognizer.automaticallyDismiss) {
         [CRToastManager dismissNotification:YES];
     }
-    tapGestureRecognizer.block(tapGestureRecognizer.interactionType);
+    
+    if (tapGestureRecognizer.block) {
+        tapGestureRecognizer.block(tapGestureRecognizer.interactionType);
+    }
 }
 
 #pragma mark - Overrides


### PR DESCRIPTION
Passing a nil block into the CRToastInteractionResponder convenience method would cause a crash when the gesture recognizer was fired. I have added checks to make sure the block exists before calling it. 

Since the toast has an option to automatically dismiss, it is possible that there doesn't need to be a completion block.

I also considered making a second class method without the block parameter, as per below. I've left that out for now, but I could add it in if it's agreed to be useful. 

``` obj-c
+ (instancetype)interactionResponderWithInteractionType:(CRToastInteractionType)interactionType 
                                   automaticallyDismiss:(BOOL)automaticallyDismiss;
```
