### PR TITLE
Fix to display notification correctly when started from landscape or upside-down orientation

### DIFF
--- a/CRToast/CRToast.m
+++ b/CRToast/CRToast.m
@@ -1070,6 +1070,14 @@ static CGFloat const CRStatusBarViewUnderStatusBarYOffsetAdjustment = -5;
 
 UIStatusBarStyle statusBarStyle;
 
+- (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil {
+    self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
+    if (self) {
+        _autorotate = YES;
+    }
+    return self;
+}
+
 - (BOOL)prefersStatusBarHidden {
     return [UIApplication sharedApplication].statusBarHidden;
 }


### PR DESCRIPTION
In order to reproduce the issue:
1. Open Demo project and run it under iPad Simulator
2. Go to landscape mode, close the app
3. Run it again in landscape mode from the start
4. Turn off all switches except ViewController Status Bar
5. Set Entrance and Exit Animation Types to Gravity
6. Enter some message text
7. Tap Show Notification button
8. You will see weird animation

P.S. Feel free to test with different animation types and from different initial orientations. 
