### PR TITLE
Fix bug where +dismissAllNotifications: does not respect the animated flag

### DIFF
--- a/CRToast/CRToast.h
+++ b/CRToast/CRToast.h
@@ -363,6 +363,6 @@ extern NSString *const kCRToastAutorotateKey;
  Immidiately begins the (un)animated dismisal of a notification and canceling all others
  @param animated If YES the notification will dismiss with its configure animation, otherwise it will immidiately disappear
  */
-+ (void) dismissAllNotifications:(BOOL)animated;
++ (void)dismissAllNotifications:(BOOL)animated;
 
 @end

--- a/CRToast/CRToast.m
+++ b/CRToast/CRToast.m
@@ -1127,7 +1127,7 @@ typedef void (^CRToastAnimationStepBlock)(void);
 }
 
 + (void)dismissAllNotifications:(BOOL)animated {
-    [[self manager] dismissAllNotifications:YES];
+    [[self manager] dismissAllNotifications:animated];
 }
 
 + (instancetype)manager {


### PR DESCRIPTION
Currently +dismissAllNotifications: ignores the `animated` flag and always passes `YES`.
