### PR TITLE
Make documentation for kCRToastStatusBarStyleKey more accurate.

### DIFF
--- a/CRToast/CRToast.h
+++ b/CRToast/CRToast.h
@@ -290,7 +290,7 @@ extern NSString *const kCRToastSubtitleTextShadowOffsetKey;
 extern NSString *const kCRToastSubtitleTextMaxNumberOfLinesKey;
 
 /**
- The status bar style for the navigation bar.  Expects type `NSInteger`.
+ The status bar style for the navigation bar.  Expects type `UIStatusBarStyle`.
  */
 
 extern NSString *const kCRToastStatusBarStyleKey;


### PR DESCRIPTION
Values for this key should be UIStatusBarStyles, not arbitrary NSIntegers.
