### PR TITLE
Fixes first display in landscape on iPad

### DIFF
--- a/CRToast/CRToast.m
+++ b/CRToast/CRToast.m
@@ -7,6 +7,8 @@
 #import <QuartzCore/QuartzCore.h>
 #import "CRToast.h"
 
+#define DegreesToRadians(degrees) (degrees * M_PI / 180)
+
 NSString *NSStringFromCRToastInteractionType(CRToastInteractionType interactionType) {
     switch (interactionType) {
         case CRToastInteractionTypeSwipeUp:
@@ -1147,6 +1149,7 @@ typedef void (^CRToastAnimationStepBlock)(void);
         notificationWindow.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
         notificationWindow.windowLevel = UIWindowLevelStatusBar;
         notificationWindow.rootViewController = [CRToastViewController new];
+        notificationWindow.rootViewController.view.transform = [self transformForOrientation:[UIApplication sharedApplication].statusBarOrientation];
         notificationWindow.rootViewController.view.clipsToBounds = YES;
         self.notificationWindow = notificationWindow;
         
@@ -1388,5 +1391,25 @@ CRToastAnimationStepBlock CRToastOutwardAnimationsSetupBlock(CRToastManager *wea
         self.gravityAnimationCompletionBlock = NULL;
     }
 }
+
+#pragma mark - Adjusting rotation
+
+- (CGAffineTransform)transformForOrientation:(UIInterfaceOrientation)orientation {
+    switch (orientation) {
+        case UIInterfaceOrientationLandscapeLeft:
+            return CGAffineTransformMakeRotation(-DegreesToRadians(90));
+            
+        case UIInterfaceOrientationLandscapeRight:
+            return CGAffineTransformMakeRotation(DegreesToRadians(90));
+            
+        case UIInterfaceOrientationPortraitUpsideDown:
+            return CGAffineTransformMakeRotation(DegreesToRadians(180));
+            
+        case UIInterfaceOrientationPortrait:
+        default:
+            return CGAffineTransformMakeRotation(DegreesToRadians(0));
+    }
+}
+
 
 @end


### PR DESCRIPTION
Before rotating, if the app is launch in landscape and the notification
is displayed, avoids some strange issue related to rotation.
Fixes #83
