### PR TITLE
Fix: Don't ask travis to update xctool anymore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,3 @@ language: objective-c
 xcode_project: CRToastDemo.xcodeproj
 xcode_scheme: CRToastTests
 xcode_sdk: iphonesimulator7.0
-before_script:
-  - brew update
-  - brew upgrade xctool


### PR DESCRIPTION
Travis have upgraded to the latest xctool. Running `brew upgrade xctool` has a failure exit status if it is up to date (handy!). So let's err on the side of upgrade xctool when we start having problems with xctool.
