### PR TITLE
Support for Rubymotion

### DIFF
--- a/CRToast/CRToast.m
+++ b/CRToast/CRToast.m
@@ -903,7 +903,7 @@ static CGFloat kCRCollisionTweak = 0.5;
     NSMutableDictionary *cleanOptions = [options mutableCopy];
     [options enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
         //Check keys validity followed by checking objects type validity
-        if ([kCRToastKeyClassMap.allKeys indexOfObjectIdenticalTo:key] == NSNotFound) {
+        if ([kCRToastKeyClassMap.allKeys indexOfObject:key] == NSNotFound) {
             NSLog(@"[CRToast] : ERROR given unrecognized key %@ in options with object %@",
                   key,
                   obj);


### PR DESCRIPTION
Huge fan of this excellent cocoapod! I've been using it with Rubymotion but since version 0.6 it mysteriously stopped working. 

Some further investigation shows that the NSDictionary that Rubymotion creates from hashes doesn't seem to gel well with `indexOfObjectIdenticalTo`, perhaps something to do with the way constants are handled? This change allows CRToast to be used with Rubymotion while keeping the valid key checking intact, hoping this is an acceptable compromise?
