### PR TITLE
Fix layout issues on iOS 8 (tested on iPad) when rotated

### DIFF
--- a/CRToast/CRToast.m
+++ b/CRToast/CRToast.m
@@ -82,6 +82,13 @@ typedef NS_ENUM(NSInteger, CRToastState) {
     CRToastStateCompleted
 };
 
+// Manually define the foundation version number for iOS 7.1, used to check if
+// device is running iOS 8 or later, in order to pass Travis CI. Can be removed
+// once Travis CI is updated to support Xcode 6 and iOS 8 SDK.
+#ifndef NSFoundationVersionNumber_iOS_7_1
+	#define NSFoundationVersionNumber_iOS_7_1 1047.25
+#endif
+
 #pragma mark - CRToast
 
 @interface CRToast : NSObject <UIGestureRecognizerDelegate>


### PR DESCRIPTION
iOS 8 now returns proper frame values adjusted for orientation. This PR prevent adjustments to frame when running on iOS 8.
