### PR TITLE
bug fix with iPhone 6 Plus in Landscape mode

### DIFF
--- a/CRToast/CRToast.m
+++ b/CRToast/CRToast.m
@@ -1386,9 +1386,9 @@ CRToastAnimationStepBlock CRToastOutwardAnimationsSetupBlock(CRToastManager *wea
     CGSize notificationSize = CRNotificationViewSize(notification.notificationType, notification.preferredHeight);
     
     CGRect containerFrame;
-    if ([[[UIDevice currentDevice] systemVersion] floatValue] > 7.1f && [UIScreen mainScreen].nativeScale > 2) {
+    UIInterfaceOrientation interfaceOrientation = [[UIApplication sharedApplication] statusBarOrientation];
+    if ([[[UIDevice currentDevice] systemVersion] floatValue] > 7.1f && [UIScreen mainScreen].nativeScale > 2 && interfaceOrientation == UIInterfaceOrientationLandscapeLeft) {
         containerFrame = CGRectMake(0, 0, notificationSize.width, notificationSize.height + 11);
-        
     } else {
         containerFrame = CGRectMake(0, 0, notificationSize.width, notificationSize.height);
     }

--- a/CRToast/CRToast.m
+++ b/CRToast/CRToast.m
@@ -1385,8 +1385,14 @@ CRToastAnimationStepBlock CRToastOutwardAnimationsSetupBlock(CRToastManager *wea
     _notificationWindow.hidden = NO;
     CGSize notificationSize = CRNotificationViewSize(notification.notificationType, notification.preferredHeight);
     
-    CGRect containerFrame = CGRectMake(0, 0, notificationSize.width, notificationSize.height);
-	
+    CGRect containerFrame;
+    if ([[[UIDevice currentDevice] systemVersion] floatValue] > 7.1f && [UIScreen mainScreen].nativeScale > 2) {
+        containerFrame = CGRectMake(0, 0, notificationSize.width, notificationSize.height + 11);
+        
+    } else {
+        containerFrame = CGRectMake(0, 0, notificationSize.width, notificationSize.height);
+    }
+    
 	if (!kCRFrameAutoAdjustedForOrientation) {
 		UIInterfaceOrientation statusBarOrientation = CRGetDeviceOrientation();
 		switch (statusBarOrientation) {

--- a/CRToast/CRToast.m
+++ b/CRToast/CRToast.m
@@ -1422,18 +1422,11 @@ CRToastAnimationStepBlock CRToastOutwardAnimationsSetupBlock(CRToastManager *wea
     _notificationWindow.rootViewController.view.frame = containerFrame;
     _notificationWindow.windowLevel = notification.displayUnderStatusBar ? UIWindowLevelNormal + 1 : UIWindowLevelStatusBar;
     
-    UIView *statusBarView = notification.statusBarView;
-    statusBarView.frame = _notificationWindow.rootViewController.view.bounds;
-    [_notificationWindow.rootViewController.view addSubview:statusBarView];
-    self.statusBarView = statusBarView;
-    statusBarView.hidden = notification.presentationType == CRToastPresentationTypeCover;
-    
     UIView *notificationView = notification.notificationView;
     notificationView.frame = notification.notificationViewAnimationFrame1;
     [_notificationWindow.rootViewController.view addSubview:notificationView];
     self.notificationView = notificationView;
     rootViewController.toastView = notificationView;
-    self.statusBarView = statusBarView;
     
     for (UIView *subview in _notificationWindow.rootViewController.view.subviews) {
         subview.userInteractionEnabled = NO;
@@ -1480,11 +1473,7 @@ CRToastAnimationStepBlock CRToastOutwardAnimationsSetupBlock(CRToastManager *wea
         case CRToastAnimationTypeGravity: {
             [notification initiateAnimator:_notificationWindow.rootViewController.view];
             [notification.animator removeAllBehaviors];
-            UIGravityBehavior *gravity = [[UIGravityBehavior alloc]initWithItems:@[notificationView, statusBarView]];
-            gravity.gravityDirection = notification.inGravityDirection;
-            gravity.magnitude = notification.animationGravityMagnitude;
             NSMutableArray *collisionItems = [@[notificationView] mutableCopy];
-            if (notification.presentationType == CRToastPresentationTypePush) [collisionItems addObject:statusBarView];
             UICollisionBehavior *collision = [[UICollisionBehavior alloc] initWithItems:collisionItems];
             collision.collisionDelegate = self;
             [collision addBoundaryWithIdentifier:kCRToastManagerCollisionBoundryIdentifier
@@ -1492,7 +1481,6 @@ CRToastAnimationStepBlock CRToastOutwardAnimationsSetupBlock(CRToastManager *wea
                                          toPoint:notification.inCollisionPoint2];
             UIDynamicItemBehavior *rotationLock = [[UIDynamicItemBehavior alloc] initWithItems:collisionItems];
             rotationLock.allowsRotation = NO;
-            [notification.animator addBehavior:gravity];
             [notification.animator addBehavior:collision];
             [notification.animator addBehavior:rotationLock];
             self.gravityAnimationCompletionBlock = inwardAnimationsCompletionBlock;


### PR DESCRIPTION
There is a bug by using this library for an iPhone 6 Plus. The CRToast will not hide the navigationbar completly. With the added lines of code it fixes the bug.
