### PR TITLE
Fix runtime crash when compiled with iOS 8 running on iOS 7

### DIFF
--- a/CRToast/CRToastLayoutHelpers.h
+++ b/CRToast/CRToastLayoutHelpers.h
@@ -15,7 +15,7 @@
  */
 static inline BOOL CRFrameAutoAdjustedForOrientation() {
 #ifdef __IPHONE_8_0
-    return YES;
+    return [[UIScreen mainScreen] respondsToSelector:@selector(traitCollection)];
 #else
     return NO;
 #endif
@@ -27,7 +27,7 @@ static inline BOOL CRFrameAutoAdjustedForOrientation() {
  */
 static inline BOOL CRUseSizeClass() {
 #ifdef __IPHONE_8_0
-    return YES;
+    return [[UIScreen mainScreen] respondsToSelector:@selector(traitCollection)];
 #else
     return NO;
 #endif


### PR DESCRIPTION
Made an incorrect assumption -- when compiled under iOS 8 SDK but iOS 7 support is required, this will call `traitCollection` which causes an unknown selector crash.

```
Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[UIScreen traitCollection]: unrecognized selector sent to instance 0x7b537370'
```

This should fix that assumption & crash