### PR TITLE
Fix Activity Indicator center alignment being shifted left

### DIFF
--- a/CRToast/CRToastView.m
+++ b/CRToast/CRToastView.m
@@ -77,7 +77,7 @@ static CGFloat CRCenterXForActivityIndicatorWithAlignment(CRToastAccessoryViewAl
         case CRToastAccessoryViewAlignmentLeft:
             center = offset; break;
         case CRToastAccessoryViewAlignmentCenter:
-            center = (contentWidth / 2) - offset; break;
+            center = (contentWidth / 2); break;
         case CRToastAccessoryViewAlignmentRight:
             center = contentWidth - offset; break;
     }
@@ -140,7 +140,7 @@ static CGFloat CRCenterXForActivityIndicatorWithAlignment(CRToastAccessoryViewAl
                                       0 :
                                       CGRectGetHeight(contentFrame));
     
-    CGFloat imageWidth = imageSize.width == 0 ? kCRStatusBarViewNoImageLeftContentInset : CGRectGetMaxX(_imageView.frame);
+    CGFloat imageWidth = imageSize.width == 0 ? 0 : CGRectGetMaxX(_imageView.frame);
     CGFloat x = CRContentXOffsetForViewAlignmentAndWidth(self.toast.imageAlignment, imageWidth);
     
     if (self.toast.showActivityIndicator) {

--- a/Tests/Unit Tests/CRToastViewTests.m
+++ b/Tests/Unit Tests/CRToastViewTests.m
@@ -110,7 +110,7 @@ CRToast * __TestToast(void) {
     toast.options = options;
     self.view.toast = toast;
     
-    CGPoint assumedCenter = CGPointMake(150, 50);
+    CGPoint assumedCenter = self.view.center;
     
     [self.view layoutSubviews];
     

--- a/Tests/Unit Tests/CRToastViewTests.m
+++ b/Tests/Unit Tests/CRToastViewTests.m
@@ -110,7 +110,7 @@ CRToast * __TestToast(void) {
     toast.options = options;
     self.view.toast = toast;
     
-    CGPoint assumedCenter = CGPointMake(100, 50);
+    CGPoint assumedCenter = CGPointMake(150, 50);
     
     [self.view layoutSubviews];
     


### PR DESCRIPTION
Also fix centered text with no image being shifted right 10 pixels too far

This fixes https://github.com/cruffenach/CRToast/issues/131 in regards to the activity indicator being shifted left incorrectly when it should be centered.
Also fixes centered text being shifted slightly to the right because of an incorrect value check.