### PR TITLE
don't use @import without a good reason to do so

### DIFF
--- a/CRToast/CRToast.h
+++ b/CRToast/CRToast.h
@@ -5,7 +5,7 @@
 
 #import <Foundation/Foundation.h>
 #import "CRToastManager.h"
-@import UIKit;
+#import <UIKit/UIKit.h>
 
 @class CRToastSwipeGestureRecognizer, CRToastTapGestureRecognizer;
 


### PR DESCRIPTION
using module imports causes unnecessary problems with projects in which modules are disabled, which seems to be the default as soon as ObjectiveC++ is involved. I don't see a reason why `@import UIKit` would be favourable over `#import <UIKit/UIKit.h>`, so I've refactored the code to the latter to avoid these problems.