### PR TITLE
Fix alignment for when multiple items are centered

### DIFF
--- a/CRToast/CRToastView.m
+++ b/CRToast/CRToastView.m
@@ -202,7 +202,7 @@ static CGFloat CRCenterXForActivityIndicatorWithAlignment(CRToastAccessoryViewAl
                                               subtitleHeight);
     }
     
-    // account for center alignment crap
+    // Account for center alignment of text and an accessory view
     if ((showingImage || self.toast.showActivityIndicator)
         && (self.toast.activityViewAlignment == CRToastAccessoryViewAlignmentCenter
             || self.toast.imageAlignment == CRToastAccessoryViewAlignmentCenter)

--- a/CRToast/CRToastView.m
+++ b/CRToast/CRToastView.m
@@ -201,6 +201,60 @@ static CGFloat CRCenterXForActivityIndicatorWithAlignment(CRToastAccessoryViewAl
                                               CGRectGetWidth(contentFrame)-x-kCRStatusBarViewNoImageRightContentInset,
                                               subtitleHeight);
     }
+    
+    // account for center alignment crap
+    if ((showingImage || self.toast.showActivityIndicator)
+        && (self.toast.activityViewAlignment == CRToastAccessoryViewAlignmentCenter
+            || self.toast.imageAlignment == CRToastAccessoryViewAlignmentCenter)
+        && self.toast.textAlignment == NSTextAlignmentCenter
+        ) {
+        CGFloat labelHeight = CGRectGetHeight(self.label.frame); // Store labelHeight for resetting after calling sizeToFit
+        [self.label sizeToFit]; // By default our size is rather large so lets fix that for further calculations
+        
+        CGFloat subTitleLabelHeight = CGRectGetHeight(self.label.frame); // Store labelHeight for resetting after calling sizeToFit
+        [self.subtitleLabel sizeToFit]; // Again, default size is too large so we need to shrink it down
+        
+        // Center the label in the view since we're center aligned text
+        self.label.center = (CGPoint) {
+            .x = CGRectGetMidX(self.frame),
+            .y = self.label.center.y
+        };
+        // After calling sizeToFit we need to reset our frames so they look correct
+        self.label.frame = CGRectMake(CGRectGetMinX(self.label.frame),
+                                      CGRectGetMinY(self.label.frame),
+                                      CGRectGetWidth(self.label.frame),
+                                      labelHeight);
+        
+        // Same thing as for Label
+        self.subtitleLabel.center = (CGPoint) {
+            .x = CGRectGetMidX(self.frame),
+            .y = self.subtitleLabel.center.y
+        };
+        self.subtitleLabel.frame = CGRectMake(CGRectGetMinX(self.subtitleLabel.frame),
+                                              CGRectGetMinY(self.subtitleLabel.frame),
+                                              CGRectGetWidth(self.subtitleLabel.frame),
+                                              subTitleLabelHeight);
+        
+        // Get the smallest X value so our image/activity indicator doesn't cover any thing
+        CGFloat smallestXView = MIN(CGRectGetMinX(self.label.frame), CGRectGetMinX(self.subtitleLabel.frame));
+        
+        // Move our image if that is what we're showing
+        if (showingImage && self.toast.imageAlignment == CRToastAccessoryViewAlignmentCenter) {
+            self.imageView.frame = (CGRect) {
+                .origin.x = smallestXView - CGRectGetWidth(self.imageView.frame) - preferredPadding,
+                .origin.y = self.imageView.frame.origin.y,
+                .size = self.imageView.frame.size,
+            };
+        }
+        // Move our activity indicator over.
+        if ((self.toast.showActivityIndicator && self.toast.activityViewAlignment == CRToastAccessoryViewAlignmentCenter)) {
+            self.activityIndicator.frame = (CGRect) {
+                .origin.x = smallestXView - CGRectGetWidth(self.activityIndicator.frame) - preferredPadding,
+                .origin.y = self.activityIndicator.frame.origin.y,
+                .size = self.activityIndicator.frame.size,
+            };
+        }
+    }
 }
 
 #pragma mark - Overrides

--- a/CRToast/CRToastView.m
+++ b/CRToast/CRToastView.m
@@ -238,6 +238,12 @@ static CGFloat CRCenterXForActivityIndicatorWithAlignment(CRToastAccessoryViewAl
         // Get the smallest X value so our image/activity indicator doesn't cover any thing
         CGFloat smallestXView = MIN(CGRectGetMinX(self.label.frame), CGRectGetMinX(self.subtitleLabel.frame));
         
+        // If both our labels have 0 width (empty text) don't change the centers of our
+        // image or activity indicator and just move along
+        if (CGRectGetWidth(self.label.frame) == 0.0
+            && CGRectGetWidth(self.subtitleLabel.frame) == 0.0) {
+            return;
+        }
         // Move our image if that is what we're showing
         if (showingImage && self.toast.imageAlignment == CRToastAccessoryViewAlignmentCenter) {
             self.imageView.frame = (CGRect) {

--- a/Example/Tests/Unit Tests/CRToastViewTests.m
+++ b/Example/Tests/Unit Tests/CRToastViewTests.m
@@ -48,13 +48,11 @@ CRToast * __TestToast(void) {
     toast.options = options;
     self.view.toast = toast;
     
-    CGRect assumedRect = CGRectMake(100, 0, 100, 100);
-    
     [self.view layoutSubviews];
     
-    BOOL rectsEqual = CGRectEqualToRect(assumedRect, self.view.imageView.frame);
+    BOOL centersEqual = CGPointEqualToPoint(self.view.center, self.view.imageView.center);
     
-    XCTAssertTrue(rectsEqual, @"center aligned rect should be equal to assumed rect. Intead was %@", NSStringFromCGRect(self.view.imageView.frame));
+    XCTAssertTrue(centersEqual, @"center of image view should be center of self.view (%@). Intead was %@", NSStringFromCGPoint(self.view.center), NSStringFromCGPoint(self.view.imageView.center));
 }
 
 - (void)testImageFrameRightAlignment {
@@ -113,7 +111,7 @@ CRToast * __TestToast(void) {
     
     BOOL centersEqual = CGPointEqualToPoint(assumedCenter, self.view.activityIndicator.center);
     
-    XCTAssertTrue(centersEqual, @"center aligned activity indicator center shold equal assumed center. Instead was %@", NSStringFromCGPoint(self.view.activityIndicator.center));
+    XCTAssertTrue(centersEqual, @"center aligned activity indicator center shold equal assumed center (%@). Instead was %@", NSStringFromCGPoint(self.view.center), NSStringFromCGPoint(self.view.activityIndicator.center));
 }
 
 - (void)testActivityFrameRightAlignment {
@@ -134,6 +132,48 @@ CRToast * __TestToast(void) {
     BOOL centersEqual = CGPointEqualToPoint(assumedCenter, self.view.activityIndicator.center);
     
     XCTAssertTrue(centersEqual, @"right aligned activity indicator center shold equal assumed center. Instead was %@", NSStringFromCGPoint(self.view.activityIndicator.center));
+}
+
+#pragma mark Padding
+
+- (void)testPreferredPaddingSetToZero {
+    CRToast *toast = __TestToast();
+    NSMutableDictionary *options = [NSMutableDictionary dictionary];
+    
+    options[kCRToastImageKey] = [UIImage imageNamed:@"alert_icon"];
+    options[kCRToastImageAlignmentKey] = @(CRToastAccessoryViewAlignmentLeft);
+    options[kCRToastTextKey] = @"Test";
+    options[kCRToastTextAlignmentKey] = @(NSTextAlignmentLeft);
+    options[kCRToastNotificationPreferredPaddingKey] = @0;
+    
+    toast.options = options;
+    self.view.toast = toast;
+    
+    [self.view layoutSubviews];
+    
+    CGFloat imageViewX = CGRectGetMinX(self.view.imageView.frame);
+    
+    XCTAssertTrue(imageViewX == 0.0, @"With no padding minX should be 0.0. Instead was %f", imageViewX);
+}
+
+- (void)testPrefferedPaddingIsRespectedWhenHigher {
+    CRToast *toast = __TestToast();
+    NSMutableDictionary *options = [NSMutableDictionary dictionary];
+    
+    options[kCRToastShowActivityIndicatorKey] = @YES;
+    options[kCRToastActivityIndicatorAlignmentKey] = @(CRToastAccessoryViewAlignmentLeft);
+    options[kCRToastTextKey] = @"Test";
+    options[kCRToastTextAlignmentKey] = @(NSTextAlignmentLeft);
+    options[kCRToastNotificationPreferredPaddingKey] = @20;
+    
+    toast.options = options;
+    self.view.toast = toast;
+    
+    [self.view layoutSubviews];
+    
+    CGFloat imageViewX = CGRectGetMinX(self.view.imageView.frame);
+    
+    XCTAssertTrue(imageViewX == 20.0, @"With no padding minX should be 20.0. Instead was %f", imageViewX);
 }
 
 #pragma mark Width Calculations


### PR DESCRIPTION
This accounts for an 'edge' case where we have centered text & a centered accessory view.
To account for this we move the accessory off to the left side so that the text can remain centered while not covering it up with said accessory view.

This may not be the _prettiest_ solution so I'm open to suggestions if anyone has them.

Took screen shots of the results
![ios simulator screen shot aug 1 2015 4 36 59 pm](https://cloud.githubusercontent.com/assets/511142/9024034/0595183a-386c-11e5-9fb4-614a0536b7b9.png)
![ios simulator screen shot aug 1 2015 4 37 06 pm](https://cloud.githubusercontent.com/assets/511142/9024035/05b26d0e-386c-11e5-9f6c-0746ec822127.png)

cc @nmock, @jadar