### PR TITLE
CRToastConfig: use background view from defaultOptions if set

### DIFF
--- a/CRToast/CRToastConfig.m
+++ b/CRToast/CRToastConfig.m
@@ -681,7 +681,7 @@ static NSDictionary *                kCRToastKeyClassMap                    = ni
 }
 
 - (UIView *)backgroundView {
-    return _options[kCRToastBackgroundViewKey];
+    return _options[kCRToastBackgroundViewKey] ?: kCRBackgroundView;
 }
 
 - (UIImage *)image {


### PR DESCRIPTION
Before this change, setting `kCRToastBackgroundViewKey` using `setDefaultOptions` was being ignored.