### PR TITLE
Fixed outAnimationDirection bug in CRToastConfig.m

### DIFF
--- a/CRToast/CRToastConfig.m
+++ b/CRToast/CRToastConfig.m
@@ -583,7 +583,7 @@ static NSDictionary *                kCRToastKeyClassMap                    = ni
 }
 
 - (CRToastAnimationDirection)outAnimationDirection {
-    return _options[kCRToastAnimationInDirectionKey] ?
+    return _options[kCRToastAnimationOutDirectionKey] ?
     [_options[kCRToastAnimationOutDirectionKey] integerValue] :
     kCROutAnimationDirectionDefault;
 }


### PR DESCRIPTION
This bug causes the outDirection of toasts to be default direction if inDirection is not set.