### PR TITLE
Fixed crash when snapshotting status bar

### DIFF
--- a/CRToast/CRToastConfig.m
+++ b/CRToast/CRToastConfig.m
@@ -469,7 +469,9 @@ static NSDictionary *                kCRToastKeyClassMap                    = ni
     if (!_privateStatusBarView) {
         _privateStatusBarView = [[UIView alloc] initWithFrame:self.statusBarViewAnimationFrame1];
         if (self.snapshotWindow) {
-            [_privateStatusBarView addSubview:CRStatusBarSnapShotView(self.displayUnderStatusBar)];
+		dispatch_async(dispatch_get_main_queue(), ^{
+			[_privateStatusBarView addSubview:CRStatusBarSnapShotView(self.displayUnderStatusBar)];
+		});
         }
         _privateStatusBarView.clipsToBounds = YES;
     }

--- a/CRToast/CRToastLayoutHelpers.h
+++ b/CRToast/CRToastLayoutHelpers.h
@@ -205,22 +205,17 @@ static CGRect CRGetNotificationContainerFrame(UIInterfaceOrientation statusBarOr
 
 /// Get view snapshot. If `underStatusBar` it will get key windows root view controller. Otherwise it'll get the mainscreens snapshot
 static UIView *CRStatusBarSnapShotView(BOOL underStatusBar) {
-	
 	__block UIView *snapshot;
-	
-    if([[[UIDevice currentDevice] systemVersion] floatValue] >= 8.0) {
-		dispatch_async(dispatch_get_main_queue(), ^(void){
+	dispatch_async(dispatch_get_main_queue(), ^(void){
+		if([[[UIDevice currentDevice] systemVersion] floatValue] >= 8.0) {
 			snapshot = underStatusBar ?
 			[[UIApplication sharedApplication].keyWindow.rootViewController.view snapshotViewAfterScreenUpdates:YES] :
 			[[UIScreen mainScreen] snapshotViewAfterScreenUpdates:YES];
-		});
-		return snapshot;
-    } else {
-		dispatch_async(dispatch_get_main_queue(), ^(void){
+		} else {
 			snapshot = underStatusBar ?
 			[[UIApplication sharedApplication].keyWindow.rootViewController.view snapshotViewAfterScreenUpdates:NO] :
 			[[UIScreen mainScreen] snapshotViewAfterScreenUpdates:NO];
-		});
-		return snapshot;
-    }
+		}
+	});
+    return snapshot;
 }

--- a/CRToast/CRToastLayoutHelpers.h
+++ b/CRToast/CRToastLayoutHelpers.h
@@ -205,17 +205,13 @@ static CGRect CRGetNotificationContainerFrame(UIInterfaceOrientation statusBarOr
 
 /// Get view snapshot. If `underStatusBar` it will get key windows root view controller. Otherwise it'll get the mainscreens snapshot
 static UIView *CRStatusBarSnapShotView(BOOL underStatusBar) {
-	__block UIView *snapshot;
-	dispatch_async(dispatch_get_main_queue(), ^(void){
-		if([[[UIDevice currentDevice] systemVersion] floatValue] >= 8.0) {
-			snapshot = underStatusBar ?
-			[[UIApplication sharedApplication].keyWindow.rootViewController.view snapshotViewAfterScreenUpdates:YES] :
-			[[UIScreen mainScreen] snapshotViewAfterScreenUpdates:YES];
-		} else {
-			snapshot = underStatusBar ?
-			[[UIApplication sharedApplication].keyWindow.rootViewController.view snapshotViewAfterScreenUpdates:NO] :
-			[[UIScreen mainScreen] snapshotViewAfterScreenUpdates:NO];
-		}
-	});
-    return snapshot;
+	if([[[UIDevice currentDevice] systemVersion] floatValue] >= 8.0) {
+		return underStatusBar ?
+		[[UIApplication sharedApplication].keyWindow.rootViewController.view snapshotViewAfterScreenUpdates:YES] :
+		[[UIScreen mainScreen] snapshotViewAfterScreenUpdates:YES];
+	} else {
+		return underStatusBar ?
+		[[UIApplication sharedApplication].keyWindow.rootViewController.view snapshotViewAfterScreenUpdates:NO] :
+		[[UIScreen mainScreen] snapshotViewAfterScreenUpdates:NO];
+	}
 }

--- a/CRToast/CRToastLayoutHelpers.h
+++ b/CRToast/CRToastLayoutHelpers.h
@@ -205,13 +205,22 @@ static CGRect CRGetNotificationContainerFrame(UIInterfaceOrientation statusBarOr
 
 /// Get view snapshot. If `underStatusBar` it will get key windows root view controller. Otherwise it'll get the mainscreens snapshot
 static UIView *CRStatusBarSnapShotView(BOOL underStatusBar) {
+	
+	__block UIView *snapshot;
+	
     if([[[UIDevice currentDevice] systemVersion] floatValue] >= 8.0) {
-        return underStatusBar ?
-        [[UIApplication sharedApplication].keyWindow.rootViewController.view snapshotViewAfterScreenUpdates:YES] :
-        [[UIScreen mainScreen] snapshotViewAfterScreenUpdates:YES];
+		dispatch_async(dispatch_get_main_queue(), ^(void){
+			snapshot = underStatusBar ?
+			[[UIApplication sharedApplication].keyWindow.rootViewController.view snapshotViewAfterScreenUpdates:YES] :
+			[[UIScreen mainScreen] snapshotViewAfterScreenUpdates:YES];
+		});
+		return snapshot;
     } else {
-        return underStatusBar ?
-        [[UIApplication sharedApplication].keyWindow.rootViewController.view snapshotViewAfterScreenUpdates:NO] :
-        [[UIScreen mainScreen] snapshotViewAfterScreenUpdates:NO];
+		dispatch_async(dispatch_get_main_queue(), ^(void){
+			snapshot = underStatusBar ?
+			[[UIApplication sharedApplication].keyWindow.rootViewController.view snapshotViewAfterScreenUpdates:NO] :
+			[[UIScreen mainScreen] snapshotViewAfterScreenUpdates:NO];
+		});
+		return snapshot;
     }
 }


### PR DESCRIPTION
![screen shot 2017-02-27 at 16 52 13](https://cloud.githubusercontent.com/assets/5271150/23365907/890f234c-fd0d-11e6-98d7-d84cba8d1c38.png)

As seen in the crash log above, CRToast isn't snapshotting the status bar on the main thread, which often crashes the app, especially when the thread is used. 

This pull request, modifies the `CRStatusBarSnapShotView` method to perform the snapshot on the main thread. 