### PR TITLE
Add configuration property to allow user tweak the collisiontweak factor

### DIFF
--- a/CRToast/CRToastConfig.h
+++ b/CRToast/CRToastConfig.h
@@ -102,7 +102,7 @@ typedef NS_ENUM(NSInteger, CRToastAnimationType) {
 };
 
 /**
-  `CRToastState` defines the current state of the CRToast. Used for internal state management in the manager 
+ `CRToastState` defines the current state of the CRToast. Used for internal state management in the manager
  */
 typedef NS_ENUM(NSInteger, CRToastState){
     CRToastStateWaiting,
@@ -163,7 +163,7 @@ extern NSString *const kCRToastUnderStatusBarKey;
  improved when the toast is within the border. Customized bars without the border
  should have this set to NO.
  Expects type `BOOL`. Defaults to YES.
-*/
+ */
 extern NSString *const kCRToastKeepNavigationBarBorderKey;
 
 /**
@@ -302,7 +302,7 @@ extern NSString *const kCRToastBackgroundColorKey;
 
 /**
  Custom view used as the background of the notification
-*/
+ */
 extern NSString *const kCRToastBackgroundViewKey;
 
 /**
@@ -364,6 +364,11 @@ extern NSString *const kCRToastIdentifierKey;
  A BOOL setting whether the CRToast's should capture the screen behind the default UIWindow. Expects type `BOOL` defaults to `YES`
  */
 extern NSString *const kCRToastCaptureDefaultWindowKey;
+
+/**
+ A float setting the correction in the collision calculus border. Default is 0.5 but in iOS>8 with Push of the navigationbar is better 0.0
+ */
+extern NSString *const kCRToastCollisionTweakKey;
 
 #pragma mark - CRToast Interface
 @interface CRToast : NSObject <UIGestureRecognizerDelegate>
@@ -456,3 +461,4 @@ extern NSString *const kCRToastCaptureDefaultWindowKey;
 - (void)initiateAnimator:(UIView *)view;
 
 @end
+

--- a/CRToast/CRToastConfig.m
+++ b/CRToast/CRToastConfig.m
@@ -751,7 +751,7 @@ static NSDictionary *                kCRToastKeyClassMap                    = ni
 }
 
 - (CGFloat)collisionTweak {
-    return _options[kCRToastCollisionTweakKey] ? [_options[kCRToastCollisionTweakKey] floatValue]: kCRToastCollisionTweakDefault;
+    return _options[kCRToastCollisionTweakKey] ? [_options[kCRToastCollisionTweakKey] floatValue] : kCRToastCollisionTweakDefault;
 }
 
 BOOL CRToastAnimationDirectionIsVertical(CRToastAnimationDirection animationDirection) {
@@ -762,7 +762,7 @@ BOOL CRToastAnimationDirectionIsHorizontal(CRToastAnimationDirection animationDi
     return !CRToastAnimationDirectionIsVertical(animationDirection);
 }
 
-//Este valor estaba a 0.5. Lo cambiamos a variable de configuración porque a partir de iOS>=9 hace que detecte la colisión mal y es necesario ponerlo a 0.0 ahora ver kCRToastCollisionTweakKey
+//The value was set to 0.5. We change it to a configuration variable becouse since iOS>=9 it detects the collision wrong and a value of 0.0 is needed. Now kCRToastCollisionTweakKey can be used
 //static CGFloat kCRCollisionTweak = 0.5;
 
 - (CGVector)inGravityDirection {

--- a/CRToast/CRToastView.m
+++ b/CRToast/CRToastView.m
@@ -131,7 +131,7 @@ static CGFloat CRCenterXForActivityIndicatorWithAlignment(CRToastAccessoryViewAl
     CGSize imageSize = self.imageView.image.size;
     CGFloat preferredPadding = self.toast.preferredPadding;
     
-    CGFloat statusBarYOffset = self.toast.displayUnderStatusBar ? (CRGetStatusBarHeight()+CRStatusBarViewUnderStatusBarYOffsetAdjustment) : 0;
+    CGFloat statusBarYOffset = MAX(self.toast.displayUnderStatusBar ? (CRGetStatusBarHeight()+CRStatusBarViewUnderStatusBarYOffsetAdjustment) : 0, 0);
     contentFrame.size.height = CGRectGetHeight(contentFrame) - statusBarYOffset;
     
     self.backgroundView.frame = self.bounds;

--- a/Example/CRToastDemo.xcodeproj/project.pbxproj
+++ b/Example/CRToastDemo.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		5E2FFB6918367C01003333F8 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5E2FFB6818367C01003333F8 /* Images.xcassets */; };
 		5E2FFB8E18367CA3003333F8 /* MainViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E2FFB8C18367CA3003333F8 /* MainViewController.m */; };
 		5E2FFB8F18367CA3003333F8 /* MainViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5E2FFB8D18367CA3003333F8 /* MainViewController.xib */; };
+		A046EB0820359D6400AFF1D2 /* Launch.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A046EB0720359D6400AFF1D2 /* Launch.storyboard */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -82,6 +83,7 @@
 		5E2FFB8B18367CA3003333F8 /* MainViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MainViewController.h; sourceTree = "<group>"; };
 		5E2FFB8C18367CA3003333F8 /* MainViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MainViewController.m; sourceTree = "<group>"; };
 		5E2FFB8D18367CA3003333F8 /* MainViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = MainViewController.xib; sourceTree = "<group>"; };
+		A046EB0720359D6400AFF1D2 /* Launch.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Launch.storyboard; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -148,6 +150,7 @@
 				5E2FFB8D18367CA3003333F8 /* MainViewController.xib */,
 				5E2FFB6818367C01003333F8 /* Images.xcassets */,
 				5E2FFB5D18367C01003333F8 /* Supporting Files */,
+				A046EB0720359D6400AFF1D2 /* Launch.storyboard */,
 			);
 			path = CRToastDemo;
 			sourceTree = "<group>";
@@ -254,6 +257,7 @@
 				5E2FFB6118367C01003333F8 /* InfoPlist.strings in Resources */,
 				5E2FFB8F18367CA3003333F8 /* MainViewController.xib in Resources */,
 				5E2FFB6918367C01003333F8 /* Images.xcassets in Resources */,
+				A046EB0820359D6400AFF1D2 /* Launch.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -380,7 +384,7 @@
 				GCC_PREFIX_HEADER = "CRToastDemo/CRToastDemo-Prefix.pch";
 				GCC_WARN_PEDANTIC = YES;
 				INFOPLIST_FILE = "CRToastDemo/CRToastDemo-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = CRToastDemo;
@@ -405,7 +409,7 @@
 				GCC_PREFIX_HEADER = "CRToastDemo/CRToastDemo-Prefix.pch";
 				GCC_WARN_PEDANTIC = YES;
 				INFOPLIST_FILE = "CRToastDemo/CRToastDemo-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = CRToastDemo;

--- a/Example/CRToastDemo/CRToastDemo-Info.plist
+++ b/Example/CRToastDemo/CRToastDemo-Info.plist
@@ -24,6 +24,8 @@
 	<string>1.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>Launch</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>

--- a/Example/CRToastDemo/Launch.storyboard
+++ b/Example/CRToastDemo/Launch.storyboard
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+    </dependencies>
+    <scenes/>
+</document>


### PR DESCRIPTION
The constant defined to allow fine adjusting of gravity animations creates some problem with custom height notifications in versions iOS>8 it works perfect in 8 and less.
To allow old versions instead of removing the tweak i extract the constant as a new option in the options dictionary

To test in phoneX is needed a Launch Storyboard and to change the SDK version