### PR TITLE
Hotfix/interaction type 0.0.10

### DIFF
--- a/CRToast.podspec
+++ b/CRToast.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'CRToast'
-  s.version  = '0.0.9'
+  s.version  = '0.0.10'
   s.license  = 'MIT'
   s.summary  = 'A modern iOS toast view that can fit your notification needs'
   s.homepage = 'https://github.com/cruffenach/CRToast'

--- a/CRToast/CRToastConfig.m
+++ b/CRToast/CRToastConfig.m
@@ -77,7 +77,7 @@ BOOL CRToastInteractionResponderIsSwipe(CRToastInteractionType interactionType) 
     return CRToastInteractionTypeSwipe & interactionType;
 }
 
-BOOL CRToastInteractionResponderIsTap(interactionType) {
+BOOL CRToastInteractionResponderIsTap(CRToastInteractionType interactionType) {
     return CRToastInteractionTypeTap & interactionType;
 }
 


### PR DESCRIPTION
Xcode 16 compilation not detect the type of interactionType.
<img width="1400" alt="image" src="https://github.com/user-attachments/assets/5b31b960-a791-45e1-89eb-3c2151e8993f">

Add `CRToastInteractionType` to declare interactionType.
